### PR TITLE
replace prisma graphql extension

### DIFF
--- a/starter-files/gatsby/.vscode/extensions.json
+++ b/starter-files/gatsby/.vscode/extensions.json
@@ -3,7 +3,7 @@
     "dbaeumer.vscode-eslint",
     "wesbos.theme-cobalt2",
     "formulahendry.auto-rename-tag",
-    "Prisma.vscode-graphql",
+    "graphql.vscode-graphql",
     "jpoissonnier.vscode-styled-components"
   ]
 }

--- a/starter-files/sanity/.vscode/extensions.json
+++ b/starter-files/sanity/.vscode/extensions.json
@@ -3,7 +3,7 @@
     "dbaeumer.vscode-eslint",
     "wesbos.theme-cobalt2",
     "formulahendry.auto-rename-tag",
-    "Prisma.vscode-graphql",
+    "graphql.vscode-graphql",
     "jpoissonnier.vscode-styled-components"
   ]
 }


### PR DESCRIPTION
Hey @wesbos 

The Prisma GraphQL extension was renamed to `graphql.vscode-graphql` and the current one no longer exists in the Marketplace. https://twitter.com/GraphiQL/status/1308786048848326656

I updated the extension in both the VSC files. 🙂 