### PR TITLE
fix missing topping data from all-sample-data.gz

### DIFF
--- a/starter-files/sanity/sample-data/text-data.md
+++ b/starter-files/sanity/sample-data/text-data.md
@@ -6,7 +6,7 @@ chimi hendirx
 
 Here Comes Truffle
 * Roasted Garlic
-* Mushroom
+* Mushrooms
 * Truffle
 
 Dough Exotic
@@ -49,20 +49,20 @@ The Pear Necessities
 * Honey
 
 Pepperphony
-* Vegan Pepperoi
+* Vegan Pepperoni
 * Vegan Cheese
 * Peppers
 * Basil
 
 Holy Shiitake
-* Garlic
+* Roasted Garlic
 * Mushrooms
 * Onions
 * Truffle
 
 Cluck Norris
 * Chicken
-* Onion
+* Onions
 * Hot Peppers
 
 


### PR DESCRIPTION
Working through the course, and having a blast!

In video 20, I tried to import the dataset but noticed that it did not include the toppings. This new GZ contains a fresh dataset that adds the toppings and relinks them to pizza items.
