### PR TITLE
order.js a11y and styling fix 

### DIFF
--- a/finished-files/gatsby/src/pages/order.js
+++ b/finished-files/gatsby/src/pages/order.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { graphql } from 'gatsby';
 import Img from 'gatsby-image';
 import SEO from '../components/SEO';
@@ -40,22 +40,26 @@ export default function OrderPage({ data }) {
       <OrderStyles onSubmit={submitOrder}>
         <fieldset disabled={loading}>
           <legend>Your Info</legend>
-          <label htmlFor="name">Name</label>
-          <input
-            type="text"
-            name="name"
-            id="name"
-            value={values.name}
-            onChange={updateValue}
-          />
-          <label htmlFor="email">Email</label>
-          <input
-            type="email"
-            name="email"
-            id="email"
-            value={values.email}
-            onChange={updateValue}
-          />
+          <label htmlFor="name">
+            Name
+            <input
+              type="text"
+              name="name"
+              id="name"
+              value={values.name}
+              onChange={updateValue}
+            />
+          </label>
+          <label htmlFor="email">
+            Email
+            <input
+              type="email"
+              name="email"
+              id="email"
+              value={values.email}
+              onChange={updateValue}
+            />
+          </label>
           <input
             type="mapleSyrup"
             name="mapleSyrup"

--- a/finished-files/gatsby/src/styles/OrderStyles.js
+++ b/finished-files/gatsby/src/styles/OrderStyles.js
@@ -8,9 +8,14 @@ const OrderStyles = styled.form`
     grid-column: span 2;
     max-height: 600px;
     overflow: auto;
-    display: grid;
-    gap: 1rem;
-    align-content: start;
+    label {
+      display: grid;
+      gap: 1rem;
+      align-content: start;
+    }
+    label + label {
+      margin-top: 1rem;
+    }
     &.order,
     &.menu {
       grid-column: span 1;


### PR DESCRIPTION
I noticed that that a11y fixes for the linting error in `order.js` weren't in the final files.
This PR adds the fix and adjusts the styles to match the UI in the videos.

The sibling selector I added (`label + label`) is for a Chrome fix.

Thanks for this awesome course! I've learned a ton!

Base Repo after a11y fix:
![Screen Shot 2020-10-03 at 11 06 13 AM](https://user-images.githubusercontent.com/9326234/94996271-2d9e8300-0569-11eb-8eca-76ac83079b9f.png)

PR Repo:
![Screen Shot 2020-10-03 at 11 11 35 AM](https://user-images.githubusercontent.com/9326234/94996278-4313ad00-0569-11eb-8995-98ff99e5f70e.png)
