### PR TITLE
Update SEO on Slicemasters Template

### DIFF
--- a/finished-files/gatsby/src/templates/Slicemaster.js
+++ b/finished-files/gatsby/src/templates/Slicemaster.js
@@ -6,7 +6,7 @@ import SEO from '../components/SEO';
 export default function SlicemasterPage({ data: { person } }) {
   return (
     <>
-      <SEO title={person.name} image={person.image.asset.src} />
+      <SEO title={person.name} image={person.image?.asset?.fluid?.src} />
       <div className="center">
         <Img fluid={person.image.asset.fluid} />
         <h2>

--- a/stepped-solutions/33/Slicemaster.js
+++ b/stepped-solutions/33/Slicemaster.js
@@ -6,7 +6,7 @@ import SEO from '../components/SEO';
 export default function SlicemasterPage({ data: { person } }) {
   return (
     <>
-      <SEO title={person.name} image={person.image.asset.src} />
+      <SEO title={person.name} image={person.image?.asset?.fluid?.src} />
       <div className="center">
         <Img fluid={person.image.asset.fluid} />
         <h2>


### PR DESCRIPTION
I noticed that on lesson 33  (SEO) the path for the image of the slicemaster was missing the `fluid` property before accessing the `src`.

Also, I added the optional chaining to help prevent issues when the image is missing. As suggested in the `Pizza.js` template