### PR TITLE
add missing styles to fieldsets in order page

### DIFF
--- a/finished-files/gatsby/src/styles/OrderStyles.js
+++ b/finished-files/gatsby/src/styles/OrderStyles.js
@@ -5,6 +5,8 @@ const OrderStyles = styled.form`
   grid-template-columns: 1fr 1fr;
   gap: 20px;
   fieldset {
+    display: grid;
+    gap: 1rem;
     grid-column: span 2;
     max-height: 600px;
     overflow: auto;


### PR DESCRIPTION
Hey Wes,

I added 2 styles that were missing from the finished files. When I checked https://gatsby.pizza I could see those styles on the fieldset and they are used in the course.