### PR TITLE
accessibility improvements

### DIFF
--- a/finished-files/gatsby/src/components/LoadingGrid.js
+++ b/finished-files/gatsby/src/components/LoadingGrid.js
@@ -12,7 +12,7 @@ export default function LoadingGrid({ count }) {
           <img
             src="data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUAAAAECAQAAADsOj3LAAAADklEQVR42mNkgANGQkwAAJoABWH6GPAAAAAASUVORK5CYII="
             className="loading"
-            alt="Loading"
+            alt=""
             width="500"
             height="400"
           />

--- a/finished-files/gatsby/src/pages/order.js
+++ b/finished-files/gatsby/src/pages/order.js
@@ -113,7 +113,7 @@ export default function OrderPage({ data }) {
           <h3>
             Your Total is {formatMoney(calculateOrderTotal(order, pizzas))}
           </h3>
-          <div>{error ? <p>Error: {error}</p> : ''}</div>
+          <div aria-live="polite" aria-atomic="true">{error ? <p>Error: {error}</p> : ''}</div>
           <button type="submit" disabled={loading}>
             {loading ? 'Placing Order...' : 'Order Ahead'}
           </button>

--- a/finished-files/gatsby/src/pages/order.js
+++ b/finished-files/gatsby/src/pages/order.js
@@ -115,7 +115,10 @@ export default function OrderPage({ data }) {
           </h3>
           <div aria-live="polite" aria-atomic="true">{error ? <p>Error: {error}</p> : ''}</div>
           <button type="submit" disabled={loading}>
-            {loading ? 'Placing Order...' : 'Order Ahead'}
+            <span aria-live="assertive" aria-atomic="true">
+              {loading ? 'Placing Order...' : ''}
+            </span>
+            {loading ? '' : 'Order Ahead'}
           </button>
         </fieldset>
       </OrderStyles>


### PR DESCRIPTION
While I've not done a full a11y review, these three issues jumped out at me as I went through the course.

## Loading alt text
The first is to remove "Loading" from the alt tag in the grid. These placeholder images are "decorative only" and do not serve a useful purpose.

In a perfect world, the entire loading grid might be refactored so that there was a single, screen reader only H2 heading at the top saying "Loading" or "Loading slice masters" above that section and "loading slices" above that section. Then the rest of the loading grid would be aria-hidden. This would likely be better for AT users. 

However, that is a fair bit of refactoring and would likely require some focus control. 

At the minimum removing "Loading" from the image alt will cut back on some of the noise during the load.

This is a minor improvement, but a step in the right direction.

The bigger issue I saw was the notifications.

## Placing Order

After placing an order the button title changes to "placing order..." This works great for users who can see the change, but no notification of that change exists for SR users.

This creates one of the worst possible outcomes ... silence after an action.

When an action is taken, users need to know something happened. If they get silence, they will think they did something wrong.

Even worse, now that the button and fields are disabled, it will feel like something is broken. This is a REALLY bad UX for non-sighted users.

To combat this, this PR adds an aria-live="assertive" span inside the button. This will always exist (it has to) and the text "placing order..." will be announced after clicking the button. That is a huge improvement for a11y.

A couple notes.

 - aria-live="assertive" means this will announce the change immediately, interrupting anything else. This is not something you want to do often, but in this case the announcement should happen immediately after clicking the button even if more descriptions are being read.
 - aria-atomic="true" means that any time the content is updated, it will be read. This enables the button to work more than once, in case of errors etc. 
 - The aria-live is added to a container inside the button so that it can be updated with "placing order..." and only make that announcement. If it were added to the button it would announce "Order Ahead" after the error is updated if an error happens, which would be confusing.

## Error notifications
Similarly, if an error is returned, there is no notification. Even worse, the error message is loaded *before* the button, so after the button is clicked a person would have to navigate backwards at the right time to find any errors. That is far from ideal.

Instead, the error notification div is given aria-live="polite" and aria-atomic="true". 

This will make it so that the error will be announced.

Some notes
 - aria-live="polite": This is the most common use for aria-live. By doing the error this way, if the user navigated around the page after clicking "Order Ahead" but before an error is returned, they will get the message *after* whatever is being read is finished. It "waits" for a good time to let them know. 
 - aria-atomic="true": This allows the container to be used again for additional messages should a second attempt to submit the order result in another error.

## Additional Comments
I've just completed the course. I think there was something else that I remembered seeing that should be fixed for accessibility, but I couldn't remember. I thought maybe some of these things might be changed so I didn't run right out and make a PR right away. 

If you'd like I could look into actual a11y testing of the created site and submit additional PRs. These were the ones that really jumped out at me. 

It might be a good idea to use aria-live on the orders panel, for example, so that when new items are added it is announced. Also when clicking "remove" it may be good to announce that action was successful. 

There is a fine line between being helpful with announcements and annoying. 

Just some general thoughts on what might be good to improve accessibility and usability. 