### PR TITLE
Fix styling for order column when few items are in cart

### DIFF
--- a/finished-files/gatsby/src/styles/MenuItemStyles.js
+++ b/finished-files/gatsby/src/styles/MenuItemStyles.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 const MenuItemStyles = styled.div`
   display: grid;
@@ -8,6 +8,7 @@ const MenuItemStyles = styled.div`
   align-content: center;
   align-items: center;
   position: relative;
+  max-height: 100px;
   .gatsby-image-wrapper {
     grid-row: span 2;
     height: 100%;

--- a/finished-files/gatsby/src/styles/OrderStyles.js
+++ b/finished-files/gatsby/src/styles/OrderStyles.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from "styled-components";
 
 const OrderStyles = styled.form`
   display: grid;
@@ -21,6 +21,7 @@ const OrderStyles = styled.form`
     &.order,
     &.menu {
       grid-column: span 1;
+      align-content: flex-start;
       /* Chrome is weird about Grid and fieldsets, so we add a fixed height to fix it :)  */
       height: 600px;
     }


### PR DESCRIPTION
When opening the starter files for Master Gatsby and navigating to the Order Ahead link at the /order URL if you add one item to the cart you might noticed a stretched image in the middle of the column. 

You can fix this by adding a `max-height: 100px` (can make larger if you want items to be bigger at first) in the `MenuItemStyles`.

To fix the items being in the middle of the column you can add `align-content: flex-start` to the `&.order, &.menu` class in `OrderStyles.js`.

Before:
![image](https://user-images.githubusercontent.com/23741323/102018504-9198b100-3d3b-11eb-8fe1-a1dd5c427b17.png)

After:
![image](https://user-images.githubusercontent.com/23741323/102018648-72e6ea00-3d3c-11eb-8dc4-ab32ff363fb0.png)

