### PR TITLE
Update OrderStyles.js

### DIFF
--- a/finished-files/gatsby/src/styles/OrderStyles.js
+++ b/finished-files/gatsby/src/styles/OrderStyles.js
@@ -18,7 +18,11 @@ const OrderStyles = styled.form`
     label + label {
       margin-top: 1rem;
     }
-    &.order,
+  &.order {
+      grid-column: span 1;
+      height: auto;
+      align-content: start;
+    }
     &.menu {
       grid-column: span 1;
       /* Chrome is weird about Grid and fieldsets, so we add a fixed height to fix it :)  */


### PR DESCRIPTION
Discovered a bug in the image sizing and alignments on the .order column. Separating .order and .menu and adding "align-content" start will fix the issue.