### PR TITLE
Update MenuItemStyles.js

### DIFF
--- a/finished-files/gatsby/src/styles/MenuItemStyles.js
+++ b/finished-files/gatsby/src/styles/MenuItemStyles.js
@@ -4,6 +4,8 @@ const MenuItemStyles = styled.div`
   display: grid;
   grid-template-columns: 100px 1fr;
   grid-template-rows: 1fr 1fr;
+  max-height: 100px;
+  min-height: 100px;
   gap: 0 1.3rem;
   align-content: center;
   align-items: center;


### PR DESCRIPTION
add max-height and min-height to keep the images on in the .order column consistent with my other pull request in the "OrderStyles" file